### PR TITLE
Improve extraction workflow

### DIFF
--- a/.github/workflows/extract-and-publish.yaml
+++ b/.github/workflows/extract-and-publish.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if bun ./script.mts; then
+          if bun ./script.mts --update; then
             echo "has_updates=true" >> $GITHUB_OUTPUT
           else
             status=$?

--- a/.github/workflows/extract-dry-run.yaml
+++ b/.github/workflows/extract-dry-run.yaml
@@ -30,7 +30,17 @@ jobs:
       - name: Extract files (dry run)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bun ./script.mts --update
+        run: |
+          set +e
+          bun ./script.mts --update
+          status=$?
+          set -e
+
+          if [ "$status" -eq 2 ]; then
+            exit 0
+          fi
+
+          exit "$status"
 
       - name: Sync lockfile
         run: bun install

--- a/.github/workflows/extract-dry-run.yaml
+++ b/.github/workflows/extract-dry-run.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Extract files (dry run)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bun ./script.mts --force
+        run: bun ./script.mts --update
 
       - name: Sync lockfile
         run: bun install

--- a/script.mts
+++ b/script.mts
@@ -8,7 +8,9 @@ const REPOS = ['microsoft/vscode', 'microsoft/vscode-eslint'] as const;
 const UPDATE = process.argv.includes('--update');
 
 type GitHubRelease = {
+  draft?: boolean;
   name?: string;
+  prerelease?: boolean;
   tag_name?: string;
 };
 
@@ -33,7 +35,9 @@ async function getLatestReleaseVersion(repo: string): Promise<string> {
   if (!res.ok) throw new Error(`Failed to fetch the latest release for ${repo}: ${res.status} ${res.statusText}`);
 
   const releases = (await res.json()) as GitHubRelease[];
-  const release = releases.find((release) => !release.name?.toLowerCase().includes('copilot'));
+  const release = releases.find(
+    (release) => !release.draft && !release.prerelease && !release.name?.toLowerCase().includes('copilot'),
+  );
   const version = release?.tag_name?.match(/\d+\.\d+\.\d+/)?.[0];
   if (!version) throw new Error(`Failed to parse a version number from the latest release tag for ${repo}`);
 

--- a/script.mts
+++ b/script.mts
@@ -5,7 +5,12 @@ type Repo = (typeof REPOS)[number];
 
 const NO_UPDATES_EXIT_CODE = 2;
 const REPOS = ['microsoft/vscode', 'microsoft/vscode-eslint'] as const;
-const FORCE = process.argv.includes('--force');
+const UPDATE = process.argv.includes('--update');
+
+type GitHubRelease = {
+  name?: string;
+  tag_name?: string;
+};
 
 async function writeExecutable(path: string, text: string): Promise<void> {
   const withShebang = text.startsWith('#!') ? text : `#!/usr/bin/env node\n${text}`;
@@ -14,7 +19,7 @@ async function writeExecutable(path: string, text: string): Promise<void> {
 }
 
 async function getLatestReleaseVersion(repo: string): Promise<string> {
-  const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
+  const res = await fetch(`https://api.github.com/repos/${repo}/releases`, {
     headers: {
       Accept: 'application/vnd.github+json',
       'X-GitHub-Api-Version': '2026-03-10',
@@ -27,8 +32,9 @@ async function getLatestReleaseVersion(repo: string): Promise<string> {
   });
   if (!res.ok) throw new Error(`Failed to fetch the latest release for ${repo}: ${res.status} ${res.statusText}`);
 
-  const data = (await res.json()) as { tag_name?: string };
-  const version = data.tag_name?.match(/\d+\.\d+\.\d+/)?.[0];
+  const releases = (await res.json()) as GitHubRelease[];
+  const release = releases.find((release) => !release.name?.toLowerCase().includes('copilot'));
+  const version = release?.tag_name?.match(/\d+\.\d+\.\d+/)?.[0];
   if (!version) throw new Error(`Failed to parse a version number from the latest release tag for ${repo}`);
 
   return version;
@@ -107,43 +113,57 @@ async function main(): Promise<void> {
     metadata: { versions: Record<Repo, string> };
   };
 
-  console.log('Checking for updates...');
-  const latestVersions = Object.fromEntries(
-    await Promise.all(REPOS.map(async (repo) => [repo, await getLatestReleaseVersion(repo)] as const)),
-  ) as Record<Repo, string>;
+  const versions = { ...packageJson.metadata.versions };
+  let updates: Repo[] = [];
 
-  const updates = REPOS.filter((repo) => {
-    const isUpdate = packageJson.metadata.versions[repo] !== latestVersions[repo];
-    console.log(
-      isUpdate
-        ? `Update available for ${repo}: ${packageJson.metadata.versions[repo]} -> ${latestVersions[repo]}`
-        : `${repo} is already at latest version (${latestVersions[repo]})`,
-    );
-    return isUpdate;
-  });
+  if (UPDATE) {
+    console.log('Checking for updates...');
+    const latestVersions = Object.fromEntries(
+      await Promise.all(REPOS.map(async (repo) => [repo, await getLatestReleaseVersion(repo)] as const)),
+    ) as Record<Repo, string>;
 
-  if (updates.length === 0) {
-    console.log('---');
-    if (!FORCE) {
+    updates = REPOS.filter((repo) => {
+      const isUpdate = packageJson.metadata.versions[repo] !== latestVersions[repo];
+      console.log(
+        isUpdate
+          ? `Update available for ${repo}: ${packageJson.metadata.versions[repo]} -> ${latestVersions[repo]}`
+          : `${repo} is already at latest version (${latestVersions[repo]})`,
+      );
+      return isUpdate;
+    });
+
+    if (updates.length === 0) {
+      console.log('---');
       console.log('All packages are already up to date. Nothing to do.');
       process.exit(NO_UPDATES_EXIT_CODE);
     }
-    console.log('All packages are already up to date. Downloading and extracting anyway because --force was passed.');
+
+    Object.assign(versions, latestVersions);
+  } else {
+    console.log('Building pinned package versions...');
+    for (const repo of REPOS) {
+      console.log(`${repo}: ${versions[repo]}`);
+    }
   }
 
   console.log('---');
   console.log('Downloading all packages...');
   await rm('./dist', { recursive: true, force: true });
 
-  await extractVscode(latestVersions['microsoft/vscode']);
-  await extractEslint(latestVersions['microsoft/vscode-eslint']);
-  packageJson.dependencies = await getVscodeExtensionsDependencies(latestVersions['microsoft/vscode']);
+  await extractVscode(versions['microsoft/vscode']);
+  await extractEslint(versions['microsoft/vscode-eslint']);
+  packageJson.dependencies = await getVscodeExtensionsDependencies(versions['microsoft/vscode']);
 
-  Object.assign(packageJson.metadata.versions, latestVersions);
+  Object.assign(packageJson.metadata.versions, versions);
 
   await Bun.write('./package.json', `${JSON.stringify(packageJson, null, 2)}\n`);
 
   console.log('---');
+  if (!UPDATE) {
+    console.log('Rebuilt pinned package versions');
+    return;
+  }
+
   if (updates.length === 0) {
     console.log('Rebuilt packages without upstream version changes');
     return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     // Environment setup & latest features
     "lib": ["ESNext"],
+    "types": ["bun"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary

- Make `bun ./script.mts` rebuild the pinned upstream versions from `package.json`.
- Add `bun ./script.mts --update` for checking latest upstream versions, updating metadata, and rebuilding.
- Filter Copilot-named VS Code releases when selecting the latest VS Code release.
- Update extraction workflows to use `--update`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extraction and dry-run processes now support an explicit update mode to detect and apply upstream version changes during extraction.
  * Rebuilds without update mode continue to use pinned versions and skip upstream checks.
  * TypeScript configuration updated to include Bun type definitions for improved tooling compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/T1ckbase/vscode-langservers-extracted/pull/4)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->